### PR TITLE
Fix ROI type from number to percentage

### DIFF
--- a/CRM/Campaign/KPI.php
+++ b/CRM/Campaign/KPI.php
@@ -231,7 +231,7 @@ class CRM_Campaign_KPI {
       $kpi["roi"] = array(
          "id" => "roi",
          "title" => "ROI",
-         "kpi_type" => "number",
+         "kpi_type" => "percentage",
          "vis_type" => "none",
          "description" => "Return on investment",
          "value" => $total_revenue / (($total_costs == 0.00) ? 1.00 : $total_costs),


### PR DESCRIPTION
Small fix. I think that `ROI` should be presented as a percentage, the same as a `Total Revenue Reached`. That's right?
