### PR TITLE
Fix parent campaign order being reversed in campaign view

### DIFF
--- a/partials/campaign_dashboard.html
+++ b/partials/campaign_dashboard.html
@@ -5,7 +5,7 @@
          <div class="parents">
            {{ts('Parent Campaign(s)', {domain: 'de.systopia.campaign'})}} [{{numberof.parents}}]:
            <!-- parents -->
-           <a ng-repeat-start="(key, value) in parents | orderBy:'$index':true" href="#/campaign/{{value.id}}/view" ng-if="numberof.parents > 0">{{value.title}}</a> <span ng-repeat-end>&gt; </span>
+           <a ng-repeat-start="(key, value) in parents | orderBy:'$index':false" href="#/campaign/{{value.id}}/view" ng-if="numberof.parents > 0">{{value.title}}</a> <span ng-repeat-end>&gt; </span>
            <a ng-if="numberof.parents == 0">{{ts('This is a root campaign', {domain: 'de.systopia.campaign'})}}</a>
            <!-- current -->
            <a href="#/campaign/{{currentCampaign.id}}/view" class="current" ng-if="numberof.parents > 0">{{currentCampaign.title}}</a>


### PR DESCRIPTION
This fixes an issue in Civi 5.7 where the parent campaigns are shown in reversed order on top of the `/campaign/:id/view` view (after "Parent Campaign(s):").

`parents` is set via `crmApi('CampaignTree', 'getparentids', {id: $route.current.params.id})`, which already seems to reverse the array order, so we'd reverse to the original order in which root campaigns come last.

This was tested against Civi 4.6 and 5.7. Surprisingly, the order was already correct in Civi 4.6. Since the `crmApi('CampaignTree', ...)` result was in the same order on 4.6 and 5.7, I'm assuming the `orderBy` filter was simply not applied under 4.6, which just happened to make it work. Angular was upgraded from 1.3 to 1.5 between those releases, so it might have been related to that.