### PR TITLE
Allow ordering campaigns by any field

### DIFF
--- a/CRM/CampaignTree/BAO/Campaign.php
+++ b/CRM/CampaignTree/BAO/Campaign.php
@@ -136,14 +136,29 @@ class CRM_CampaignTree_BAO_Campaign extends CRM_Campaign_DAO_Campaign
       }
     }
 
+    $campaignTypeID   = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'campaign_type', 'id', 'name');
+    $campaignStatusID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'campaign_status', 'id', 'name');
+
     $query = "
-            SELECT  camp.*, createdBy.sort_name as created_by
+            SELECT camp.*, 
+            createdBy.sort_name as created_by, 
+            option_campaign_types.label as campaign_type_label,
+            option_campaign_status.label as campaign_status_label
             FROM  civicrm_campaign camp
+
             LEFT JOIN civicrm_contact createdBy
             ON createdBy.id = camp.created_id
+
+            LEFT JOIN civicrm_option_value option_campaign_types
+            ON option_campaign_types.option_group_id = {$campaignTypeID} AND option_campaign_types.value = camp.campaign_type_id
+
+            LEFT JOIN civicrm_option_value option_campaign_status
+            ON option_campaign_status.option_group_id = {$campaignStatusID} AND option_campaign_status.value = camp.status_id
+
             WHERE $whereClause
             {$orderBy}
             {$limit}";
+
 
     $object = CRM_Core_DAO::executeQuery($query, $params, TRUE, 'CRM_Campaign_DAO_Campaign');
     //skip total if we are making call to show only children

--- a/CRM/CampaignTree/Page/AJAX.php
+++ b/CRM/CampaignTree/Page/AJAX.php
@@ -40,7 +40,11 @@ class CRM_CampaignTree_Page_AJAX {
         0 => 'camp.title',
         1 => 'camp.description',
         2 => 'camp.start_date',
-        3 => 'camp.end_date'
+        3 => 'camp.end_date',
+        4 => 'campaign_type_label',
+        5 => 'campaign_status_label',
+        6 => 'createdBy.sort_name',   
+        7 => 'camp.external_identifier'
       );
       $sEcho = isset($_REQUEST['sEcho']) ? CRM_Utils_Type::escape($_REQUEST['sEcho'], 'Integer') : 1;
       $offset = isset($_REQUEST['iDisplayStart']) ? CRM_Utils_Type::escape($_REQUEST['iDisplayStart'], 'Integer') : 0;


### PR DESCRIPTION
Hello @bjendres 

I created a new branch with a change in the order of the campaigns, now it can be sorted by any field in the dashboard. I hope you like it.

Issue core: https://lab.civicrm.org/dev/core/issues/992

Thanks!