### PR TITLE
Improve pie chart for KPI visualisation

### DIFF
--- a/css/campaign.css
+++ b/css/campaign.css
@@ -133,11 +133,11 @@ piechart svg {
   margin: auto;
 }
 
-piechart svg g.slice text.hovertext {
+piechart svg g.slice .hovertext {
   display: none;
 }
 
-piechart svg g.slice:hover text.hovertext {
+piechart svg g.slice:hover .hovertext {
   display: block;
 }
 

--- a/css/campaign.css
+++ b/css/campaign.css
@@ -128,6 +128,22 @@
   text-align: center;
 }
 
+piechart path.slice {
+  stroke-width:2px;
+}
+
+piechart .labels text.hidden,
+piechart .lines polyline.hidden {
+  display: none;
+}
+
+piechart polyline {
+  opacity: .3;
+  stroke: black;
+  stroke-width: 2px;
+  fill: none;
+}
+
 piechart svg {
   display: block;
   margin: auto;

--- a/css/campaign.css
+++ b/css/campaign.css
@@ -133,11 +133,11 @@ piechart svg {
   margin: auto;
 }
 
-piechart svg g.slice .hovertext {
+piechart svg g.slice text.hovertext {
   display: none;
 }
 
-piechart svg g.slice:hover .hovertext {
+piechart svg g.slice:hover text.hovertext {
   display: block;
 }
 

--- a/css/campaign.css
+++ b/css/campaign.css
@@ -134,7 +134,7 @@ piechart path.slice {
 
 piechart .labels text.hidden,
 piechart .lines polyline.hidden {
-  display: none;
+  visibility: hidden;
 }
 
 piechart polyline {
@@ -147,14 +147,6 @@ piechart polyline {
 piechart svg {
   display: block;
   margin: auto;
-}
-
-piechart svg g.slice .hovertext {
-  display: none;
-}
-
-piechart svg g.slice:hover .hovertext {
-  display: block;
 }
 
 linegraph svg {

--- a/css/campaign.css
+++ b/css/campaign.css
@@ -133,6 +133,14 @@ piechart svg {
   margin: auto;
 }
 
+piechart svg g.slice text.hovertext {
+  display: none;
+}
+
+piechart svg g.slice:hover text.hovertext {
+  display: block;
+}
+
 linegraph svg {
   display: block;
   margin: auto;

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -428,7 +428,8 @@
               return "translate(" + arc.centroid(d) + ")";
             })
           .attr("text-anchor", "middle")
-          .text( function(d, i) {return data[i].label;} );
+          .text( function(d, i) {return data[i].label;} )
+          .attr("class", function(d, i) { return data[i].value <= 0.2 ? "hovertext": "" });
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -421,12 +421,15 @@
 
         // add label
         var labels = enter.append("svg:g").attr("class", "slice");
-        labels.append("svg:text").attr("transform", function(d){
-        			d.innerRadius = 0;
-        			d.outerRadius = r;
-            return "translate(" + arc.centroid(d) + ")";})
-                   .attr("text-anchor", "middle")
-                   .text( function(d, i) {return data[i].label;} );
+        labels.append("svg:text")
+          .attr("transform",
+            function(d) {
+        	    d.innerRadius = 0;
+        	    d.outerRadius = r;
+              return "translate(" + arc.centroid(d) + ")";
+            })
+          .attr("text-anchor", "middle")
+          .text( function(d, i) {return data[i].label;} );
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -393,6 +393,8 @@
         var color = d3.scale.category20c();
 
         var data = chartdata.value;
+        // Sort by value for coherent rendering.
+        data.sort((a, b) => (a.value > b.value) ? 1 : -1);
 
         angular.forEach(data, function(d, i) {
           if(typeof(d.label) === 'undefined' || typeof(d.value) === 'undefined' || d.value === false) {
@@ -441,10 +443,10 @@
           textElement.style.display = null;
 
           const backgroundRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          backgroundRect.setAttribute('x', bbox.x);
-          backgroundRect.setAttribute('y', bbox.y);
-          backgroundRect.setAttribute('width', bbox.width);
-          backgroundRect.setAttribute('height', bbox.height);
+          backgroundRect.setAttribute('x', bbox.x - 5);
+          backgroundRect.setAttribute('y', bbox.y - 5);
+          backgroundRect.setAttribute('width', bbox.width + 10);
+          backgroundRect.setAttribute('height', bbox.height + 10);
           backgroundRect.setAttribute('transform', textElement.getAttribute('transform'));
           backgroundRect.setAttribute('fill', '#FFFFFF80');
 

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -420,7 +420,8 @@
             });
 
         // add label
-        arcs.append("svg:text")
+        var labels = enter.append("svg:g").attr("class", "slice");
+        labels.append("svg:text")
           .attr("transform",
             function(d) {
         	    d.innerRadius = 0;
@@ -428,33 +429,7 @@
               return "translate(" + arc.centroid(d) + ")";
             })
           .attr("text-anchor", "middle")
-          .text( function(d, i) {return data[i].label;} )
-          .attr("class", function(d, i) { return data[i].value < 0.2 ? "hovertext": "" });
-
-        // Add background colours for the text elements; this is achieved with rects of the same size and position:
-        const textElements = document.querySelectorAll('g.slice text');
-        for (const textElement of textElements.values())
-        {
-          // Make sure the element is visible for the bounding box to not be empty:
-          textElement.style.display = 'block';
-          const bbox = textElement.getBBox();
-          textElement.style.display = null;
-
-          const backgroundRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          backgroundRect.setAttribute('x', bbox.x);
-          backgroundRect.setAttribute('y', bbox.y);
-          backgroundRect.setAttribute('width', bbox.width);
-          backgroundRect.setAttribute('height', bbox.height);
-          backgroundRect.setAttribute('transform', textElement.getAttribute('transform'));
-          backgroundRect.setAttribute('fill', '#FFFFFF80');
-
-          if (textElement.classList.contains('hovertext'))
-          {
-            backgroundRect.classList.add('hovertext');
-          }
-
-          textElement.parentNode.insertBefore(backgroundRect, textElement);
-        }
+          .text( function(d, i) {return data[i].label;} );
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -387,14 +387,16 @@
         var chartdata=scope[attrs.chartdata];
         var d3 = $window.d3;
 
-        var w = 300;
-        var h = 300;
-        var r = h/2;
+        var width = 600;
+        var height = 300;
+        var radius = Math.min(width, height) / 2;
         var color = d3.scale.category20c();
 
         var data = chartdata.value;
         // Sort by value for coherent rendering.
         data.sort((a, b) => (a.value > b.value) ? 1 : -1);
+
+        console.log(data);
 
         angular.forEach(data, function(d, i) {
           if(typeof(d.label) === 'undefined' || typeof(d.value) === 'undefined' || d.value === false) {
@@ -407,56 +409,121 @@
           data.push({label: ts('No Data'), value: 100});
         }
 
-        var vis = d3.select(elem[0]).append("svg:svg").data([data]).attr("width", w).attr("height", h).append("svg:g").attr("transform", "translate(" + r + "," + r + ")");
-        var pie = d3.layout.pie().value(function(d){return d.value;});
-        var arc = d3.svg.arc().outerRadius(r);
+        var svg = d3.select(elem[0])
+          .append("svg:svg")
+          .style('width', width)
+          .style('height', height)
+          .append("g");
 
-        var enter = vis.selectAll("g.slice").data(pie).enter();
-        var arcs  = enter.insert("svg:g",":first-child").attr("class", "slice");
-        arcs.append("svg:path")
-            .attr("fill", function(d, i){
-                return color(i);
-            })
-            .attr("d", function (d) {
-                return arc(d);
-            });
+        svg.append("g")
+          .attr("class", "slices");
+        svg.append("g")
+          .attr("class", "labels");
+        svg.append("g")
+          .attr("class", "lines");
 
-        // add label
-        arcs.append("svg:text")
-          .attr("transform",
-            function(d) {
-        	    d.innerRadius = 0;
-        	    d.outerRadius = r;
-              return "translate(" + arc.centroid(d) + ")";
-            })
-          .attr("text-anchor", "middle")
-          .text( function(d, i) {return data[i].label;} )
-          .attr("class", function(d, i) { return data[i].value < 0.2 ? "hovertext": "" });
+        var pie = d3.layout.pie()
+          .sort(null)
+          .value(function(d) {
+            return d.value;
+          });
 
-        // Add background colours for the text elements; this is achieved with rects of the same size and position:
-        const textElements = document.querySelectorAll('g.slice text');
-        for (const textElement of textElements.values())
-        {
-          // Make sure the element is visible for the bounding box to not be empty:
-          textElement.style.display = 'block';
-          const bbox = textElement.getBBox();
-          textElement.style.display = null;
+        var arc = d3.svg.arc()
+          .outerRadius(radius * 0.8)
+          .innerRadius(radius * 0.4);
 
-          const backgroundRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-          backgroundRect.setAttribute('x', bbox.x - 5);
-          backgroundRect.setAttribute('y', bbox.y - 5);
-          backgroundRect.setAttribute('width', bbox.width + 10);
-          backgroundRect.setAttribute('height', bbox.height + 10);
-          backgroundRect.setAttribute('transform', textElement.getAttribute('transform'));
-          backgroundRect.setAttribute('fill', '#FFFFFF80');
+        var outerArc = d3.svg.arc()
+          .innerRadius(radius * 0.9)
+          .outerRadius(radius * 0.9);
 
-          if (textElement.classList.contains('hovertext'))
-          {
-            backgroundRect.classList.add('hovertext');
+        svg.attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
+
+        var key = function(d){ return d.data.label; };
+
+        /* ------- PIE SLICES -------*/
+        function toggleLabel(d, i) {
+          var label = svg.select('.labels text[data-index="' + i + '"]')
+          var line = svg.select('.lines polyline[data-index="' + i + '"]')
+          if (label.classed('hide')) {
+            label.classed('hidden', !label.classed('hidden'));
           }
-
-          textElement.parentNode.insertBefore(backgroundRect, textElement);
+          if (line.classed('hide')) {
+            line.classed('hidden', !line.classed('hidden'));
+          }
         }
+
+        var slice = svg.select(".slices").selectAll("path.slice")
+          .data(pie(data), key);
+
+        slice.enter()
+          .insert("path")
+          .style("fill", function(d) { return color(d.data.label); })
+          .attr("class", "slice")
+          .attr('d', arc)
+          .on('mouseover', toggleLabel)
+          .on('mouseout', toggleLabel)
+          .on('touchstart', toggleLabel)
+          .on('touchend', toggleLabel);
+
+        slice.exit()
+          .remove();
+
+        /* ------- TEXT LABELS -------*/
+
+        function midAngle(d){
+          return d.startAngle + (d.endAngle - d.startAngle)/2;
+        }
+
+        var text = svg.select(".labels").selectAll("text")
+          .data(pie(data), key);
+
+        text.enter()
+          .append("text")
+          .attr("dy", ".35em")
+          .text(function(d) {
+            return d.data.label;
+          })
+          .attr('transform', function(d) {
+            var pos = outerArc.centroid(d);
+            pos[0] = radius * (midAngle(d) < Math.PI ? 1 : -1);
+            return "translate("+ pos +")";
+          })
+          .style('text-anchor', function(d) {
+            return midAngle(d) < Math.PI ? "start":"end";
+          })
+          .attr('data-index', function(d, i) {
+            return i;
+          })
+          .classed('hidden hide', function(d) {
+            return d.data.value < 0.1;
+          });
+
+        text.exit()
+          .remove();
+
+        /* ------- SLICE TO TEXT POLYLINES -------*/
+
+        var polyline = svg.select(".lines").selectAll("polyline")
+          .data(pie(data), key);
+
+        polyline.enter()
+          .append("polyline");
+
+        polyline
+          .attr('points', function(d) {
+            var pos = outerArc.centroid(d);
+            pos[0] = radius * 0.95 * (midAngle(d) < Math.PI ? 1 : -1);
+            return [arc.centroid(d), outerArc.centroid(d), pos];
+          })
+          .attr('data-index', function(d, i) {
+            return i;
+          })
+          .classed('hidden hide', function(d) {
+            return d.data.value < 0.1;
+          });
+
+        polyline.exit()
+          .remove();
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -390,13 +390,12 @@
         var width = 600;
         var height = 300;
         var radius = Math.min(width, height) / 2;
+        var labelWidth = (width - Math.min(width, height)) / 2;
         var color = d3.scale.category20c();
 
         var data = chartdata.value;
         // Sort by value for coherent rendering.
         data.sort((a, b) => (a.value > b.value) ? 1 : -1);
-
-        console.log(data);
 
         angular.forEach(data, function(d, i) {
           if(typeof(d.label) === 'undefined' || typeof(d.value) === 'undefined' || d.value === false) {
@@ -479,7 +478,6 @@
 
         text.enter()
           .append("text")
-          .attr("dy", ".35em")
           .text(function(d) {
             return d.data.label;
           })
@@ -496,6 +494,12 @@
           })
           .classed('hidden hide', function(d) {
             return d.data.value < 0.1;
+          })
+          .each(function(d, i) {
+            svg_textMultiline(this, labelWidth);
+          })
+          .attr('y', function() {
+            return -(this.getBBox().height / 2);
           });
 
         text.exit()
@@ -967,5 +971,48 @@
       }
     };
   });
+
+  /**
+   * @url https://stackoverflow.com/a/38162224
+   *
+   * @param element
+   *   The SVG TEXT element to wrap.
+   * @param width
+   *   The desired width of the wrapped text.
+   */
+  function svg_textMultiline(element, width) {
+    var y = '1.15em';
+
+    /* get the text */
+    var text = element.innerHTML;
+
+    /* split the words into array */
+    var words = text.split(' ');
+    var line = '';
+
+    /* Make a tspan for testing */
+    element.innerHTML = '<tspan id="PROCESSING">busy</tspan >';
+
+    for (var n = 0; n < words.length; n++) {
+      var testLine = line + words[n] + ' ';
+      var testElem = document.getElementById('PROCESSING');
+      /*  Add line in testElement */
+      testElem.innerHTML = testLine;
+      /* Messure textElement */
+      var metrics = testElem.getBoundingClientRect();
+      testWidth = metrics.width;
+
+      if (testWidth > width && n > 0) {
+        element.innerHTML += '<tspan x="0" dy="' + y + '">' + line + '</tspan>';
+        line = words[n] + ' ';
+      } else {
+        line = testLine;
+      }
+    }
+
+    element.innerHTML += '<tspan x="0" dy="' + y + '">' + line + '</tspan>';
+
+    document.getElementById("PROCESSING").remove();
+  }
 
 })(angular, CRM.$, CRM._);

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -429,7 +429,7 @@
             })
           .attr("text-anchor", "middle")
           .text( function(d, i) {return data[i].label;} )
-          .attr("class", function(d, i) { return data[i].value <= 0.2 ? "hovertext": "" });
+          .attr("class", function(d, i) { return data[i].value < 0.2 ? "hovertext": "" });
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -430,6 +430,31 @@
           .attr("text-anchor", "middle")
           .text( function(d, i) {return data[i].label;} )
           .attr("class", function(d, i) { return data[i].value < 0.2 ? "hovertext": "" });
+
+        // Add background colours for the text elements; this is achieved with rects of the same size and position:
+        const textElements = document.querySelectorAll('g.slice text');
+        for (const textElement of textElements.values())
+        {
+          // Make sure the element is visible for the bounding box to not be empty:
+          textElement.style.display = 'block';
+          const bbox = textElement.getBBox();
+          textElement.style.display = null;
+
+          const backgroundRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+          backgroundRect.setAttribute('x', bbox.x);
+          backgroundRect.setAttribute('y', bbox.y);
+          backgroundRect.setAttribute('width', bbox.width);
+          backgroundRect.setAttribute('height', bbox.height);
+          backgroundRect.setAttribute('transform', textElement.getAttribute('transform'));
+          backgroundRect.setAttribute('fill', '#FFFFFF80');
+
+          if (textElement.classList.contains('hovertext'))
+          {
+            backgroundRect.classList.add('hovertext');
+          }
+
+          textElement.parentNode.insertBefore(backgroundRect, textElement);
+        }
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -420,8 +420,7 @@
             });
 
         // add label
-        var labels = enter.append("svg:g").attr("class", "slice");
-        labels.append("svg:text")
+        arcs.append("svg:text")
           .attr("transform",
             function(d) {
         	    d.innerRadius = 0;


### PR DESCRIPTION
This reworks the campaign pie chart, especially the display of labels, which are now being displayed outside the chart, connected with a line, rather than placing them on top of the slices.

This way, the labels should be easier distinguishable.

Also, slices with less than 10% coverage do not display their labels initially, but only when hovering (with the mouse or when tapping on a touch device) over/on the pie chart slice, avoiding labels to overlap. This is not ideal, because sometimes there's enough space for all labels and sometimes they might still overlap (especially when there are long labels that get wrapped into multiple lines).