### PR TITLE
Improve Donation Heartbeat chart for KPI visualisation

### DIFF
--- a/CRM/Campaign/KPI.php
+++ b/CRM/Campaign/KPI.php
@@ -446,10 +446,10 @@ class CRM_Campaign_KPI {
      }
      // Set open-ended campaigns' end date to latest date in the chart.
      foreach ($all_contribs as &$data_point) {
-       if ($data_point['type'] == 'campaign_end' && empty($data_point['date'])) {
+       if (!empty($data_point['type']) && $data_point['type'] == 'campaign_end' && empty($data_point['date'])) {
          $data_point['date'] = $max_date->format('Y-m-d 00:00:00');
        }
-       if ($data_point['type'] == 'campaign_range' && empty($data_point['end_date'])) {
+       if (!empty($data_point['type']) && $data_point['type'] == 'campaign_range' && empty($data_point['end_date'])) {
          $data_point['end_date'] = $max_date->format('Y-m-d 00:00:00');
        }
      }

--- a/CRM/Campaign/KPI.php
+++ b/CRM/Campaign/KPI.php
@@ -407,7 +407,7 @@ class CRM_Campaign_KPI {
       $all_contribs = array();
 
       $contribution = CRM_Core_DAO::executeQuery($query_contribs);
-      $max_date = new DateTime(); // Now.
+      $max_date = NULL;
       while ($contribution->fetch()) {
         $date = new DateTime($contribution->date);
         $max_date = max($max_date, $date);

--- a/CRM/Campaign/KPI.php
+++ b/CRM/Campaign/KPI.php
@@ -407,11 +407,56 @@ class CRM_Campaign_KPI {
       $all_contribs = array();
 
       $contribution = CRM_Core_DAO::executeQuery($query_contribs);
+      $max_date = new DateTime(); // Now.
       while ($contribution->fetch()) {
         $date = new DateTime($contribution->date);
+        $max_date = max($max_date, $date);
         $date = $date->format('Y-m-d 00:00:00');
         $all_contribs[] = array("date" => $date, "value" => $contribution->value);
       }
+
+      // Add (sub) campaign start/end dates as data points.
+     $campaign_count = 0;
+     foreach ($all_ids as $campaign_id) {
+       $campaign = civicrm_api3('Campaign', 'getsingle', array('id' => $campaign_id));
+       $start_date = new DateTime($campaign['start_date']);
+       $all_contribs[] = array(
+         'date' => $start_date->format('Y-m-d 00:00:00'),
+         'value' => 0,
+         'type' => 'campaign_start',
+         'campaign' => $campaign['title'],
+       );
+       $end_date = !empty($campaign['end_date']) ? new DateTime($campaign['end_date']) : NULL;
+       $max_date = max($max_date, $start_date, $end_date);
+       $all_contribs[] = array(
+         'date' => $end_date ? $end_date->format('Y-m-d 00:00:00') : NULL,
+         'value' => 0,
+         'type' => 'campaign_end',
+         'campaign' => $campaign['title'],
+       );
+       $all_contribs[] = array(
+         'date' => $start_date->format('Y-m-d 00:00:00'),
+         'value' => 0,
+         'type' => 'campaign_range',
+         'start_date' => $start_date->format('Y-m-d 00:00:00'),
+         'end_date' => $end_date ? $end_date->format('Y-m-d 00:00:00') : NULL,
+         'pos' => $campaign_count++,
+         'campaign' => $campaign['title'],
+       );
+     }
+     // Set open-ended campaigns' end date to latest date in the chart.
+     foreach ($all_contribs as &$data_point) {
+       if ($data_point['type'] == 'campaign_end' && empty($data_point['date'])) {
+         $data_point['date'] = $max_date->format('Y-m-d 00:00:00');
+       }
+       if ($data_point['type'] == 'campaign_range' && empty($data_point['end_date'])) {
+         $data_point['end_date'] = $max_date->format('Y-m-d 00:00:00');
+       }
+     }
+     // Sort data points by date.
+     usort($all_contribs, function($a, $b) {
+       return strtotime($a['date']) - strtotime($b['date']);
+     });
 
       if (!empty($all_contribs)) {
          $kpi["donation_heartbeat"] = array(

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -550,14 +550,26 @@
             return bands_x(d['end_date']) - bands_x(d['start_date']);
           };
 
-        var chart = d3.select(elem[0]).append("svg")
+        var wrappedLabel = function(d) {
+          // Cut the label at a character count approximated based on the
+          // font-size (13px) and the band rect width.
+          var label = d.campaign.substr(0, spanW(d) / 13 * 2);
+          return (d.campaign.length > label.length ? label.concat('…') : label);
+        };
+
+        var bands_svg = d3.select(elem[0]).append("svg")
           .attr('width', width + margin.left + margin.right)
           .attr('height', height + margin.top + margin.bottom)
           .append('g')
           .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
+        bands_svg.append("g")
+          .attr("class", "bands");
+        bands_svg.append("g")
+          .attr("class", "labels");
+
         // Add spans
-        var span = chart.selectAll('.chart-span')
+        var span = bands_svg.select(".bands").selectAll('.chart-span')
           .data(data.filter(function(dataPoint) {
             return dataPoint['type'] == 'campaign_range';
           }))
@@ -571,6 +583,38 @@
           .attr('width', spanW)
           .attr('height', spanH);
 
+        bands_svg.select(".labels").selectAll("text.stroke")
+          .data(data.filter(function(dataPoint) {
+            return dataPoint['type'] == 'campaign_range';
+          }))
+          .enter()
+          .append("text")
+          .text(wrappedLabel)
+          .attr('x', spanX)
+          .attr('y', spanY)
+          .attr('dx', 4)
+          .attr('dy', spanH / 2)
+          .attr('width', spanW)
+          .attr('height', spanH)
+          .attr('stroke', 'white')
+          .attr('stroke-width', 4)
+          .style('dominant-baseline', 'middle');
+
+        bands_svg.select(".labels").selectAll("text.label")
+          .data(data.filter(function(dataPoint) {
+            return dataPoint['type'] == 'campaign_range';
+          }))
+          .enter()
+          .append("text")
+          .text(wrappedLabel)
+          .attr('x', spanX)
+          .attr('y', spanY)
+          .attr('dx', 4)
+          .attr('dy', spanH / 2)
+          .attr('width', spanW)
+          .attr('height', spanH)
+          .attr('fill', 'black')
+          .style('dominant-baseline', 'middle');
       }
     }
   });

--- a/js/campaign.js
+++ b/js/campaign.js
@@ -552,8 +552,8 @@
 
         var wrappedLabel = function(d) {
           // Cut the label at a character count approximated based on the
-          // font-size (13px) and the band rect width.
-          var label = d.campaign.substr(0, spanW(d) / 13 * 2);
+          // font-size (13px) and the chart width.
+          var label = d.campaign.substr(0, width / 13 * 2);
           return (d.campaign.length > label.length ? label.concat('…') : label);
         };
 
@@ -566,7 +566,8 @@
         bands_svg.append("g")
           .attr("class", "bands");
         bands_svg.append("g")
-          .attr("class", "labels");
+          .attr("class", "labels")
+          .attr('transform', 'translate(-' + margin.left + ', 0)');
 
         // Add spans
         var span = bands_svg.select(".bands").selectAll('.chart-span')
@@ -590,14 +591,13 @@
           .enter()
           .append("text")
           .text(wrappedLabel)
-          .attr('x', spanX)
+          .attr('x', '50%')
           .attr('y', spanY)
-          .attr('dx', 4)
           .attr('dy', spanH / 2)
-          .attr('width', spanW)
           .attr('height', spanH)
           .attr('stroke', 'white')
           .attr('stroke-width', 4)
+          .style('text-anchor', 'middle')
           .style('dominant-baseline', 'middle');
 
         bands_svg.select(".labels").selectAll("text.label")
@@ -607,13 +607,12 @@
           .enter()
           .append("text")
           .text(wrappedLabel)
-          .attr('x', spanX)
+          .attr('x', '50%')
           .attr('y', spanY)
-          .attr('dx', 4)
           .attr('dy', spanH / 2)
-          .attr('width', spanW)
           .attr('height', spanH)
           .attr('fill', 'black')
+          .style('text-anchor', 'middle')
           .style('dominant-baseline', 'middle');
       }
     }


### PR DESCRIPTION
This reworks the Donation Heartbeat line chart:

- Spans the start and end of the timeline from the earliest and latest of:
    - the first/last donation
    - the earliest campaign start date/the latest campaign end date (including all sub campaigns)
- Adds bars for the campaign and its sub campaigns under the timeline, denoting their start and end dates across the entire campaign duration