### PR TITLE
Correctly link contact custom fields in campaign view

### DIFF
--- a/api/v3/CampaignTree.php
+++ b/api/v3/CampaignTree.php
@@ -172,8 +172,15 @@ function civicrm_api3_campaign_tree_getcustominfo($params) {
       if (!empty($field['field_value'])) {
         switch ($field['field_data_type']) {
           case 'ContactReference':
-            // Return a link to the contact instead of just the display name.
-            $customInfo[$custom_group['id']]['fields'][$field_id]['value'] = '<a href="' . CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $field['contact_ref_id']) . '" title="' . ts('View contact') . '">' . $field['field_value'] . '</a>';
+            // If possible, return a link to the contact instead of just the display name.
+            if ($field['contact_ref_links']) {
+              $contact_value = $field['contact_ref_links'][0];
+            } elseif ($field['contact_ref_id']) {
+              $contact_value = '<a href="' . CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $field['contact_ref_id']) . '" title="' . ts('View contact') . '">' . $field['field_value'] . '</a>';
+            } else {
+              $contact_value = $field['field_value'];
+            }
+            $customInfo[$custom_group['id']]['fields'][$field_id]['value'] = $contact_value;
             break;
         }
       }

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.3-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.13</ver>
+    <ver>5.34</ver>
   </compatibility>
   <comments>This extension was originally developed as part of the 2015 Google Summer of Code as described at https://civicrm.org/blogs/niko-bochan/civicrm-strategic-fundraising-and-campaigning-gsoc-completion-report. Additional thanks to M. Wire, T. Pietrzkowski and K. Pomarańska.</comments>
   <civix>


### PR DESCRIPTION
I have looked into issue #95 on an instance running CiviCRM 5.38.1 with version 1.2 of this extension. By adding debug output to the code section that constructs the HTML for contact references,  I found that the array ``$field`` did not contain a member called ``contact_ref_id``. Instead, there was a one-element array called ``contact_ref_links`` whose first member was a string with a ready-made HTML link. I figured that the previous solution probably worked at some point, so I added code that prefers ``contact_ref_links[0]``if it is available (if the data provides a link already, it should probably be used, not constructed manually as the old code did) but the code will fall back to the old one if ``contact_ref_links`` is not provided but ``contact_ref_id`` is. If neither is available, a link cannot be constructed, in which case only ``$field['value]`` is returned (which in my test contained the contact name). I did not look into where the data in ``$field`` came from but I suspect it’s from a source outside of this extension. Maybe with more insight a different solution might seem preferrable but from my point of view this is the best strategy.