### PR TITLE
Rebuild civix code for PHP 8 support (and avoid deprecated warnings in PHP 7.4)

### DIFF
--- a/CRM/Campaign/Upgrader.php
+++ b/CRM/Campaign/Upgrader.php
@@ -1,0 +1,135 @@
+<?php
+use CRM_Campaign_ExtensionUtil as E;
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_Campaign_Upgrader extends CRM_Campaign_Upgrader_Base {
+
+  // By convention, functions that look like "function upgrade_NNNN()" are
+  // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
+
+  /**
+   * Example: Run an external SQL script when the module is installed.
+   *
+  public function install() {
+    $this->executeSqlFile('sql/myinstall.sql');
+  }
+
+  /**
+   * Example: Work with entities usually not available during the install step.
+   *
+   * This method can be used for any post-install tasks. For example, if a step
+   * of your installation depends on accessing an entity that is itself
+   * created during the installation (e.g., a setting or a managed entity), do
+   * so here to avoid order of operation problems.
+   */
+  // public function postInstall() {
+  //  $customFieldId = civicrm_api3('CustomField', 'getvalue', array(
+  //    'return' => array("id"),
+  //    'name' => "customFieldCreatedViaManagedHook",
+  //  ));
+  //  civicrm_api3('Setting', 'create', array(
+  //    'myWeirdFieldSetting' => array('id' => $customFieldId, 'weirdness' => 1),
+  //  ));
+  // }
+
+  /**
+   * Example: Run an external SQL script when the module is uninstalled.
+   */
+  // public function uninstall() {
+  //  $this->executeSqlFile('sql/myuninstall.sql');
+  // }
+
+  /**
+   * Example: Run a simple query when a module is enabled.
+   */
+  // public function enable() {
+  //  CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
+  // }
+
+  /**
+   * Example: Run a simple query when a module is disabled.
+   */
+  // public function disable() {
+  //   CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
+  // }
+
+  /**
+   * Example: Run a couple simple queries.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  // public function upgrade_4200(): bool {
+  //   $this->ctx->log->info('Applying update 4200');
+  //   CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
+  //   CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
+  //   return TRUE;
+  // }
+
+
+  /**
+   * Example: Run an external SQL script.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  // public function upgrade_4201(): bool {
+  //   $this->ctx->log->info('Applying update 4201');
+  //   // this path is relative to the extension base dir
+  //   $this->executeSqlFile('sql/upgrade_4201.sql');
+  //   return TRUE;
+  // }
+
+
+  /**
+   * Example: Run a slow upgrade process by breaking it up into smaller chunk.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  // public function upgrade_4202(): bool {
+  //   $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
+
+  //   $this->addTask(E::ts('Process first step'), 'processPart1', $arg1, $arg2);
+  //   $this->addTask(E::ts('Process second step'), 'processPart2', $arg3, $arg4);
+  //   $this->addTask(E::ts('Process second step'), 'processPart3', $arg5);
+  //   return TRUE;
+  // }
+  // public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
+  // public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
+  // public function processPart3($arg5) { sleep(10); return TRUE; }
+
+  /**
+   * Example: Run an upgrade with a query that touches many (potentially
+   * millions) of records by breaking it up into smaller chunks.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  // public function upgrade_4203(): bool {
+  //   $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
+
+  //   $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
+  //   $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
+  //   for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
+  //     $endId = $startId + self::BATCH_SIZE - 1;
+  //     $title = E::ts('Upgrade Batch (%1 => %2)', array(
+  //       1 => $startId,
+  //       2 => $endId,
+  //     ));
+  //     $sql = '
+  //       UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
+  //       WHERE id BETWEEN %1 and %2
+  //     ';
+  //     $params = array(
+  //       1 => array($startId, 'Integer'),
+  //       2 => array($endId, 'Integer'),
+  //     );
+  //     $this->addTask($title, 'executeSql', $sql, $params);
+  //   }
+  //   return TRUE;
+  // }
+
+}

--- a/CRM/Campaign/Upgrader/Base.php
+++ b/CRM/Campaign/Upgrader/Base.php
@@ -1,0 +1,396 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use CRM_Campaign_ExtensionUtil as E;
+
+/**
+ * Base class which provides helpers to execute upgrade logic
+ */
+class CRM_Campaign_Upgrader_Base {
+
+  /**
+   * @var CRM_Campaign_Upgrader_Base
+   */
+  public static $instance;
+
+  /**
+   * @var CRM_Queue_TaskContext
+   */
+  protected $ctx;
+
+  /**
+   * @var string
+   *   eg 'com.example.myextension'
+   */
+  protected $extensionName;
+
+  /**
+   * @var string
+   *   full path to the extension's source tree
+   */
+  protected $extensionDir;
+
+  /**
+   * @var array
+   *   sorted numerically
+   */
+  private $revisions;
+
+  /**
+   * @var bool
+   *   Flag to clean up extension revision data in civicrm_setting
+   */
+  private $revisionStorageIsDeprecated = FALSE;
+
+  /**
+   * Obtain a reference to the active upgrade handler.
+   */
+  public static function instance() {
+    if (!self::$instance) {
+      self::$instance = new CRM_Campaign_Upgrader(
+        'de.systopia.campaign',
+        E::path()
+      );
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Adapter that lets you add normal (non-static) member functions to the queue.
+   *
+   * Note: Each upgrader instance should only be associated with one
+   * task-context; otherwise, this will be non-reentrant.
+   *
+   * ```
+   * CRM_Campaign_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
+   * ```
+   */
+  public static function _queueAdapter() {
+    $instance = self::instance();
+    $args = func_get_args();
+    $instance->ctx = array_shift($args);
+    $instance->queue = $instance->ctx->queue;
+    $method = array_shift($args);
+    return call_user_func_array([$instance, $method], $args);
+  }
+
+  /**
+   * CRM_Campaign_Upgrader_Base constructor.
+   *
+   * @param $extensionName
+   * @param $extensionDir
+   */
+  public function __construct($extensionName, $extensionDir) {
+    $this->extensionName = $extensionName;
+    $this->extensionDir = $extensionDir;
+  }
+
+  // ******** Task helpers ********
+
+  /**
+   * Run a CustomData file.
+   *
+   * @param string $relativePath
+   *   the CustomData XML file path (relative to this extension's dir)
+   * @return bool
+   */
+  public function executeCustomDataFile($relativePath) {
+    $xml_file = $this->extensionDir . '/' . $relativePath;
+    return $this->executeCustomDataFileByAbsPath($xml_file);
+  }
+
+  /**
+   * Run a CustomData file
+   *
+   * @param string $xml_file
+   *   the CustomData XML file path (absolute path)
+   *
+   * @return bool
+   */
+  protected function executeCustomDataFileByAbsPath($xml_file) {
+    $import = new CRM_Utils_Migrate_Import();
+    $import->run($xml_file);
+    return TRUE;
+  }
+
+  /**
+   * Run a SQL file.
+   *
+   * @param string $relativePath
+   *   the SQL file path (relative to this extension's dir)
+   *
+   * @return bool
+   */
+  public function executeSqlFile($relativePath) {
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN,
+      $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
+    );
+    return TRUE;
+  }
+
+  /**
+   * Run the sql commands in the specified file.
+   *
+   * @param string $tplFile
+   *   The SQL file path (relative to this extension's dir).
+   *   Ex: "sql/mydata.mysql.tpl".
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function executeSqlTemplate($tplFile) {
+    // Assign multilingual variable to Smarty.
+    $upgrade = new CRM_Upgrade_Form();
+
+    $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('domainID', CRM_Core_Config::domainID());
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN, $smarty->fetch($tplFile), NULL, TRUE
+    );
+    return TRUE;
+  }
+
+  /**
+   * Run one SQL query.
+   *
+   * This is just a wrapper for CRM_Core_DAO::executeSql, but it
+   * provides syntactic sugar for queueing several tasks that
+   * run different queries
+   *
+   * @return bool
+   */
+  public function executeSql($query, $params = []) {
+    // FIXME verify that we raise an exception on error
+    CRM_Core_DAO::executeQuery($query, $params);
+    return TRUE;
+  }
+
+  /**
+   * Syntactic sugar for enqueuing a task which calls a function in this class.
+   *
+   * The task is weighted so that it is processed
+   * as part of the currently-pending revision.
+   *
+   * After passing the $funcName, you can also pass parameters that will go to
+   * the function. Note that all params must be serializable.
+   */
+  public function addTask($title) {
+    $args = func_get_args();
+    $title = array_shift($args);
+    $task = new CRM_Queue_Task(
+      [get_class($this), '_queueAdapter'],
+      $args,
+      $title
+    );
+    return $this->queue->createItem($task, ['weight' => -1]);
+  }
+
+  // ******** Revision-tracking helpers ********
+
+  /**
+   * Determine if there are any pending revisions.
+   *
+   * @return bool
+   */
+  public function hasPendingRevisions() {
+    $revisions = $this->getRevisions();
+    $currentRevision = $this->getCurrentRevision();
+
+    if (empty($revisions)) {
+      return FALSE;
+    }
+    if (empty($currentRevision)) {
+      return TRUE;
+    }
+
+    return ($currentRevision < max($revisions));
+  }
+
+  /**
+   * Add any pending revisions to the queue.
+   *
+   * @param CRM_Queue_Queue $queue
+   */
+  public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
+    $this->queue = $queue;
+
+    $currentRevision = $this->getCurrentRevision();
+    foreach ($this->getRevisions() as $revision) {
+      if ($revision > $currentRevision) {
+        $title = E::ts('Upgrade %1 to revision %2', [
+          1 => $this->extensionName,
+          2 => $revision,
+        ]);
+
+        // note: don't use addTask() because it sets weight=-1
+
+        $task = new CRM_Queue_Task(
+          [get_class($this), '_queueAdapter'],
+          ['upgrade_' . $revision],
+          $title
+        );
+        $this->queue->createItem($task);
+
+        $task = new CRM_Queue_Task(
+          [get_class($this), '_queueAdapter'],
+          ['setCurrentRevision', $revision],
+          $title
+        );
+        $this->queue->createItem($task);
+      }
+    }
+  }
+
+  /**
+   * Get a list of revisions.
+   *
+   * @return array
+   *   revisionNumbers sorted numerically
+   */
+  public function getRevisions() {
+    if (!is_array($this->revisions)) {
+      $this->revisions = [];
+
+      $clazz = new ReflectionClass(get_class($this));
+      $methods = $clazz->getMethods();
+      foreach ($methods as $method) {
+        if (preg_match('/^upgrade_(.*)/', $method->name, $matches)) {
+          $this->revisions[] = $matches[1];
+        }
+      }
+      sort($this->revisions, SORT_NUMERIC);
+    }
+
+    return $this->revisions;
+  }
+
+  public function getCurrentRevision() {
+    $revision = CRM_Core_BAO_Extension::getSchemaVersion($this->extensionName);
+    if (!$revision) {
+      $revision = $this->getCurrentRevisionDeprecated();
+    }
+    return $revision;
+  }
+
+  private function getCurrentRevisionDeprecated() {
+    $key = $this->extensionName . ':version';
+    if ($revision = \Civi::settings()->get($key)) {
+      $this->revisionStorageIsDeprecated = TRUE;
+    }
+    return $revision;
+  }
+
+  public function setCurrentRevision($revision) {
+    CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
+    // clean up legacy schema version store (CRM-19252)
+    $this->deleteDeprecatedRevision();
+    return TRUE;
+  }
+
+  private function deleteDeprecatedRevision() {
+    if ($this->revisionStorageIsDeprecated) {
+      $setting = new CRM_Core_BAO_Setting();
+      $setting->name = $this->extensionName . ':version';
+      $setting->delete();
+      CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
+    }
+  }
+
+  // ******** Hook delegates ********
+
+  /**
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+   */
+  public function onInstall() {
+    $files = glob($this->extensionDir . '/sql/*_install.sql');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+      }
+    }
+    $files = glob($this->extensionDir . '/sql/*_install.mysql.tpl');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeSqlTemplate($file);
+      }
+    }
+    $files = glob($this->extensionDir . '/xml/*_install.xml');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeCustomDataFileByAbsPath($file);
+      }
+    }
+    if (is_callable([$this, 'install'])) {
+      $this->install();
+    }
+  }
+
+  /**
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+   */
+  public function onPostInstall() {
+    $revisions = $this->getRevisions();
+    if (!empty($revisions)) {
+      $this->setCurrentRevision(max($revisions));
+    }
+    if (is_callable([$this, 'postInstall'])) {
+      $this->postInstall();
+    }
+  }
+
+  /**
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+   */
+  public function onUninstall() {
+    $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeSqlTemplate($file);
+      }
+    }
+    if (is_callable([$this, 'uninstall'])) {
+      $this->uninstall();
+    }
+    $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+      }
+    }
+  }
+
+  /**
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+   */
+  public function onEnable() {
+    // stub for possible future use
+    if (is_callable([$this, 'enable'])) {
+      $this->enable();
+    }
+  }
+
+  /**
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+   */
+  public function onDisable() {
+    // stub for possible future use
+    if (is_callable([$this, 'disable'])) {
+      $this->disable();
+    }
+  }
+
+  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
+    switch ($op) {
+      case 'check':
+        return [$this->hasPendingRevisions()];
+
+      case 'enqueue':
+        return $this->enqueuePendingRevisions($queue);
+
+      default:
+    }
+  }
+
+}

--- a/campaign.civix.php
+++ b/campaign.civix.php
@@ -91,9 +91,9 @@ function _campaign_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {
@@ -221,7 +221,8 @@ function _campaign_civix_upgrader() {
  * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
@@ -229,32 +230,7 @@ function _campaign_civix_upgrader() {
  * @return array
  */
 function _campaign_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_campaign_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
 
 /**


### PR DESCRIPTION
Extension is outdated and throw error in PHP 7.4

PHP Deprecated: Array and string offset access syntax with curly braces is deprecated

FIX: rebuild files with built in function civix generate:module