### PR TITLE
Fix no campaigns displayed on PHP8 site

### DIFF
--- a/CRM/CampaignTree/BAO/Campaign.php
+++ b/CRM/CampaignTree/BAO/Campaign.php
@@ -179,7 +179,7 @@ class CRM_CampaignTree_BAO_Campaign extends CRM_Campaign_DAO_Campaign
       $links = self::actionLinks($object->id);
       $action = array_sum(array_keys($links));
 
-      if (array_key_exists('is_active', $object)) {
+      if (array_key_exists('is_active', $object->toArray())) {
         if ($object->is_active) {
           $action -= CRM_Core_Action::ENABLE;
         } else {
@@ -503,7 +503,7 @@ class CRM_CampaignTree_BAO_Campaign extends CRM_Campaign_DAO_Campaign
    * @return array
    *   array of action links
    */
-  public function actionLinks($objectId) {
+  public static function actionLinks($objectId) {
     $links = array(
       CRM_Core_Action::VIEW => array(
         'name' => ts('View'),


### PR DESCRIPTION
This PR fixes the issue with the extension where the campaign dashboard does not display campaigns, instead, it shows processing as reported on #104.

After this PR, campaigns are now displayed as expected.
<img width="1208" alt="Screenshot 2022-12-21 at 08 05 50" src="https://user-images.githubusercontent.com/85277674/208842261-a2ae879c-567f-4ac7-8b1d-0663f3b3064b.png">

