### PR TITLE
Civix code upgrade to Civix version 23.02.1

### DIFF
--- a/campaign.civix.php
+++ b/campaign.civix.php
@@ -91,25 +91,14 @@ function _campaign_civix_mixin_polyfill() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _campaign_civix_civicrm_config(&$config = NULL) {
+function _campaign_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
-
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
   _campaign_civix_mixin_polyfill();
@@ -122,36 +111,7 @@ function _campaign_civix_civicrm_config(&$config = NULL) {
  */
 function _campaign_civix_civicrm_install() {
   _campaign_civix_civicrm_config();
-  if ($upgrader = _campaign_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
   _campaign_civix_mixin_polyfill();
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _campaign_civix_civicrm_postInstall() {
-  _campaign_civix_civicrm_config();
-  if ($upgrader = _campaign_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _campaign_civix_civicrm_uninstall() {
-  _campaign_civix_civicrm_config();
-  if ($upgrader = _campaign_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
 }
 
 /**
@@ -159,59 +119,9 @@ function _campaign_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _campaign_civix_civicrm_enable() {
+function _campaign_civix_civicrm_enable(): void {
   _campaign_civix_civicrm_config();
-  if ($upgrader = _campaign_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
   _campaign_civix_mixin_polyfill();
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _campaign_civix_civicrm_disable() {
-  _campaign_civix_civicrm_config();
-  if ($upgrader = _campaign_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _campaign_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _campaign_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_Campaign_Upgrader
- */
-function _campaign_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Campaign/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Campaign_Upgrader_Base::instance();
-  }
 }
 
 /**
@@ -230,8 +140,8 @@ function _campaign_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -294,15 +204,4 @@ function _campaign_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) 
       _campaign_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _campaign_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/campaign.php
+++ b/campaign.php
@@ -36,15 +36,6 @@ function campaign_civicrm_install() {
 }
 
 /**
- * Implementation of hook_civicrm_uninstall
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function campaign_civicrm_uninstall() {
-  _campaign_civix_civicrm_uninstall();
-}
-
-/**
  * Implementation of hook_civicrm_enable
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
@@ -54,30 +45,6 @@ function campaign_civicrm_enable() {
 
   //add/check the required option groups
   campaign_civicrm_install_options(campaign_civicrm_options());
-}
-
-/**
- * Implementation of hook_civicrm_disable
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- */
-function campaign_civicrm_disable() {
-  _campaign_civix_civicrm_disable();
-}
-
-/**
- * Implementation of hook_civicrm_upgrade
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function campaign_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _campaign_civix_civicrm_upgrade($op, $queue);
 }
 
 /**
@@ -249,22 +216,4 @@ function campaign_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
 function campaign_civicrm_coreResourceList(&$list, $region) {
   Civi::resources()
     ->addStyleFile('de.systopia.campaign', 'css/campaign.css', 0, $region);
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function campaign_civicrm_postInstall() {
-  _campaign_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function campaign_civicrm_entityTypes(&$entityTypes) {
-  _campaign_civix_civicrm_entityTypes($entityTypes);
 }

--- a/info.xml
+++ b/info.xml
@@ -23,9 +23,14 @@
   <comments>This extension was originally developed as part of the 2015 Google Summer of Code as described at https://civicrm.org/blogs/niko-bochan/civicrm-strategic-fundraising-and-campaigning-gsoc-completion-report. Additional thanks to M. Wire, T. Pietrzkowski and K. Pomara&#x144;ska.</comments>
   <civix>
     <namespace>CRM/Campaign</namespace>
-    <format>22.05.2</format>
+    <format>23.02.1</format>
   </civix>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.1</mixin>
   </mixins>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>

--- a/mixin/smarty-v2@1.0.1.mixin.php
+++ b/mixin/smarty-v2@1.0.1.mixin.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Auto-register "templates/" folder.
+ *
+ * @mixinName smarty-v2
+ * @mixinVersion 1.0.1
+ * @since 5.59
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+  $dir = $mixInfo->getPath('templates');
+  if (!file_exists($dir)) {
+    return;
+  }
+
+  $register = function() use ($dir) {
+    // This implementation has a theoretical edge-case bug on older versions of CiviCRM where a template could
+    // be registered more than once.
+    CRM_Core_Smarty::singleton()->addTemplateDir($dir);
+  };
+
+  // Let's figure out what environment we're in -- so that we know the best way to call $register().
+
+  if (!empty($GLOBALS['_CIVIX_MIXIN_POLYFILL'])) {
+    // Polyfill Loader (v<=5.45): We're already in the middle of firing `hook_config`.
+    if ($mixInfo->isActive()) {
+      $register();
+    }
+    return;
+  }
+
+  if (CRM_Extension_System::singleton()->getManager()->extensionIsBeingInstalledOrEnabled($mixInfo->longName)) {
+    // New Install, Standard Loader: The extension has just been enabled, and we're now setting it up.
+    // System has already booted. New templates may be needed for upcoming installation steps.
+    $register();
+    return;
+  }
+
+  // Typical Pageview, Standard Loader: Defer the actual registration for a moment -- to ensure that Smarty is online.
+  \Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($mixInfo, $register) {
+    if ($mixInfo->isActive()) {
+      $register();
+    }
+  });
+
+};


### PR DESCRIPTION
This extension seems to be using some non-standard methods for installing/enabling, so this Civix upgrade should be checked in those scenarios before merging. But it should definitely go into a stable `1.3` release.