### PR TITLE
Replace deprecated CRM_Core_OptionGroup::getValue()

### DIFF
--- a/CRM/Campaign/KPI.php
+++ b/CRM/Campaign/KPI.php
@@ -508,11 +508,11 @@ class CRM_Campaign_KPI {
     */
    protected static function getContributionStatusList() {
       if (!isset(self::$cache['contribution_status_list'])) {
-         $status_list = array();
-         $status_list['completed'] = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
-         $status_list['refunded']  = CRM_Core_OptionGroup::getValue('contribution_status', 'Refunded',  'name');
-         $status_list['cancelled'] = CRM_Core_OptionGroup::getValue('contribution_status', 'Cancelled', 'name');
-         $status_list['failed']    = CRM_Core_OptionGroup::getValue('contribution_status', 'Failed',    'name');
+         $status_list = [];
+         $status_list['completed'] = \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+         $status_list['refunded']  = \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Refunded');
+         $status_list['cancelled'] = \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Cancelled');
+         $status_list['failed']    = \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Failed');
          self::$cache['contribution_status_list'] = $status_list;
       }
       return self::$cache['contribution_status_list'];

--- a/api/v3/CampaignExpense.php
+++ b/api/v3/CampaignExpense.php
@@ -42,7 +42,12 @@ function civicrm_api3_campaign_expense_get($params) {
         $reply['values'][$expense_id]['description']     = '';
       }
       $reply['values'][$expense_id]['expense_type'] =
-      CRM_Core_OptionGroup::getLabel('campaign_expense_types', $reply['values'][$expense_id]['expense_type_id']);
+      $reply['values'][$expense_id]['expense_type'] = \Civi\Api4\OptionValue::get(FALSE)
+        ->addSelect('label')
+        ->addWhere('option_group_id:name', '=', 'campaign_expense_types')
+        ->addWhere('value', '=', $reply['values'][$expense_id]['expense_type_id'])
+        ->execute()
+        ->first();
     }
   }
   return $reply;


### PR DESCRIPTION
Civi 5.60 removes `CRM_Core_OptionGroup::getValue()`. This updates the code to the non-deprecated equivalent.