### PR TITLE
Fix wrong display of campaign expenses category

### DIFF
--- a/api/v3/CampaignExpense.php
+++ b/api/v3/CampaignExpense.php
@@ -41,13 +41,13 @@ function civicrm_api3_campaign_expense_get($params) {
         $reply['values'][$expense_id]['expense_type_id'] = 1;  // TODO: use default?
         $reply['values'][$expense_id]['description']     = '';
       }
-      $reply['values'][$expense_id]['expense_type'] =
+
       $reply['values'][$expense_id]['expense_type'] = \Civi\Api4\OptionValue::get(FALSE)
         ->addSelect('label')
         ->addWhere('option_group_id:name', '=', 'campaign_expense_types')
         ->addWhere('value', '=', $reply['values'][$expense_id]['expense_type_id'])
         ->execute()
-        ->first();
+        ->first()['label'];
     }
   }
   return $reply;


### PR DESCRIPTION
![Screenshot from 2024-01-29 09-45-00](https://github.com/systopia/de.systopia.campaign/assets/5382898/a2eee7f3-d0dd-4de3-a6dc-855e488b29d6)

Expenses category display whole JSON, not only label