### PR TITLE
Let CampaignCustomisationHooks pass parameter names instead of an integer

### DIFF
--- a/CRM/Utils/CampaignCustomisationHooks.php
+++ b/CRM/Utils/CampaignCustomisationHooks.php
@@ -17,7 +17,7 @@ class CRM_Utils_CampaignCustomisationHooks {
   static $null = NULL;
 
   static function campaign_kpis($campaign_id, &$kpi_list, $level) {
-    return CRM_Utils_Hook::singleton()->invoke(3, $campaign_id, $kpi_list, $level, self::$null, self::$null, self::$null, 'civicrm_campaignKpis');
+    return CRM_Utils_Hook::singleton()->invoke(["campaign_id", "kpi_list", "level"], $campaign_id, $kpi_list, $level, self::$null, self::$null, self::$null, 'civicrm_campaignKpis');
   }
 
 }


### PR DESCRIPTION
A small change to get rid of the deprecation warning.

Fixes #118