### PR TITLE
GP-43955 Replace SearchKit-based campaign dashboard

### DIFF
--- a/CRM/CampaignManager/MenuReplacer.php
+++ b/CRM/CampaignManager/MenuReplacer.php
@@ -1,0 +1,19 @@
+<?php
+
+class CRM_CampaignManager_MenuReplacer {
+
+  public static function replaceCampaignMenu(Civi\Core\Event\GenericHookEvent $event): void {
+    if ($event->items['civicrm/campaign']['page_callback'] == 'CRM_Afform_Page_AfformBase') {
+      // replace SearchKit-based campaign dashboard with extension-provided form
+      $event->items['civicrm/campaign'] = [
+        'title' => $event->items['civicrm/campaign']['title'],
+        'page_callback' => 'CRM_CampaignManager_CampaignTree_Page_Dashboard',
+        'component' => 'CiviCampaign',
+        'access_arguments' => [
+          ['administer CiviCampaign', 'manage campaign'],
+          ['or']
+        ],
+      ];
+    }
+  }
+}

--- a/campaign.php
+++ b/campaign.php
@@ -23,6 +23,13 @@ require_once 'campaign.civix.php';
  */
 function campaign_civicrm_config(&$config) {
   _campaign_civix_civicrm_config($config);
+  if (isset(Civi::$statics[__FUNCTION__])) { return; }
+  Civi::$statics[__FUNCTION__] = 1;
+  Civi::dispatcher()->addListener(
+    'hook_civicrm_alterMenu',
+    ['CRM_CampaignManager_MenuReplacer', 'replaceCampaignMenu'],
+    -1000
+  );
 }
 
 /**


### PR DESCRIPTION
This replaces the SearchKit/Afform-based campaign dashboard that started shipping with core with the extension-provided dashboard.

(Kind of) Fixes #116