### PR TITLE
Campaign dashboard form: Prepare TabHeader tabs for changed core template

### DIFF
--- a/CRM/CampaignManager/CampaignTree/Page/Dashboard.php
+++ b/CRM/CampaignManager/CampaignTree/Page/Dashboard.php
@@ -200,6 +200,10 @@ class CRM_CampaignManager_CampaignTree_Page_Dashboard extends CRM_Core_Page {
       );
     }
     $allTabs['campaign']['class'] = 'livePage';
+    // @phpstan-ignore function.alreadyNarrowedType
+    if (method_exists(CRM_Core_Smarty::class, 'setRequiredTabTemplateKeys')) {
+      $allTabs = \CRM_Core_Smarty::setRequiredTabTemplateKeys($allTabs);
+    }
     $this->assign('tabHeader', $allTabs);
   }
 }


### PR DESCRIPTION
civicrm/civicrm-core#31697 changed the `TabHeader.tpl` smarty template to require `url` keys for tabs instead of `link`.

The campaign dashboard uses core's `TabHeader.tpl` and needs to be adjusted for this core refactoring. This is being done by using the `\CRM_Core_Smarty::setRequiredTabTemplateKeys()` method added in civicrm/civicrm-core#31636 before assigning the template variable.

Without this change, tab panels are not being loaded at all starting with CiviCRM `5.82.0`.