### PR TITLE
Fix use of deprecated `addDate()` and `jcalendar.tpl`

### DIFF
--- a/CRM/CampaignManager/CampaignTree/Form/Search.php
+++ b/CRM/CampaignManager/CampaignTree/Form/Search.php
@@ -44,10 +44,10 @@ class CRM_CampaignManager_CampaignTree_Form_Search extends CRM_Core_Form {
     );
 
     //campaign start date.
-    $this->addDate('start_date', ts('Start Date'), FALSE, array('formatType' => 'searchDate'));
+    $this->add('datepicker', 'start_date', ts('Start Date'), [], FALSE, ['time' => FALSE]);
 
     //campaign end date.
-    $this->addDate('end_date', ts('End Date'), FALSE, array('formatType' => 'searchDate', 'name' => 'end_date'));
+    $this->add('datepicker', 'end_date', ts('End Date'), [], FALSE, ['time' => FALSE]);
 
     $campaignShow = array(ts('Root') => 1, ts('Parent') => 2, ts('Child') => 3, ts('Other') => 4);
     $this->addCheckBox('show',

--- a/templates/CRM/CampaignManager/CampaignTree/Form/Search.tpl
+++ b/templates/CRM/CampaignManager/CampaignTree/Form/Search.tpl
@@ -60,11 +60,11 @@
     </tr><tr>
       <td>
           {$form.start_date.label}<br />
-          {include file="CRM/common/jcalendar.tpl" elementName=start_date}
+          {$form.start_date.html}
       </td>
       <td>
           {$form.end_date.label}<br />
-          {include file="CRM/common/jcalendar.tpl" elementName=end_date}
+          {$form.end_date.html}
       </td>
       </tr><tr>
         <td id="campaign-show-block">


### PR DESCRIPTION
This fixes an issue due to a reference to `jcalendar.tpl` which no longer works in more recent version of core (see [this](https://lab.civicrm.org/dev/core/-/issues/5378) for context) and replaces the deprecated `addDate()` form method with `add('datepicker')`.

GP-46492